### PR TITLE
startApp move and configure

### DIFF
--- a/utils/startApp.js
+++ b/utils/startApp.js
@@ -1,0 +1,12 @@
+import logoutButton from '../components/buttons/logoutButton';
+import navBar from '../components/navbar';
+import homePage from '../pages/homePage';
+
+const startApp = (user) => {
+  document.querySelector('#login-form-container').innerHTML = ''; // Clear login button
+  navBar(user); // Pass user data to navbar
+  logoutButton(); // Add logout button to navbar
+  homePage(user); // Show homepage with user-specific content
+};
+
+export default startApp;

--- a/utils/viewDirector.js
+++ b/utils/viewDirector.js
@@ -1,10 +1,8 @@
 import firebase from 'firebase/app';
 import 'firebase/auth';
 import loginButton from '../components/buttons/loginButton';
-import logoutButton from '../components/buttons/logoutButton';
 import client from './client';
-import navBar from '../components/navbar';
-import homePage from '../pages/homePage';
+import startApp from './startApp';
 
 // Keep track of initialization
 let isInitialized = false;
@@ -20,10 +18,7 @@ const ViewDirectorBasedOnUserAuthStatus = () => {
   firebase.auth().onAuthStateChanged((user) => {
     if (user) {
       // person is logged in do something...
-      document.querySelector('#login-form-container').innerHTML = ''; // Clear login button
-      navBar(user); // Pass user data to navbar
-      logoutButton(); // Add logout button to navbar
-      homePage(user); // Show homepage with user-specific content
+      startApp(user);
     } else {
       // person is NOT logged in
       document.querySelector('#navigation').innerHTML = ''; // Hide navbar


### PR DESCRIPTION
## Description
- moved startApp to utils folder
- wrote startApp function that so far calls navBar, logoutButton, and homePage. 
- moved navBar, logout, and homepage out of viewDirector and instead called startApp in that spot.

## Related Issue
#60 

## Motivation and Context
This change organizes the app initialization logic into the startApp function, making the code more modular and easier to maintain. Moving these components out of viewDirector simplifies things and keeps the codebase cleaner and easier to work with.

## How Can This Be Tested?
**Checklist for testing:**
- [ ] Add the deploy preview URL (https://app.netlify.com/sites/hhpw/deploys/675771bb01391200089c07ee) for the branch to firebase authorized domains. In firebase go to authentication > settings > authorized domains and add domain
- [ ] Run the application and confirm the navigation bar, logout button, and home page display as expected.
- [ ] Verify that these components are functional and any previously working features remain unaffected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
