### PR TITLE
rendering user specific order cards to dom upon clicking view orders …

### DIFF
--- a/events/navigationEvents.js
+++ b/events/navigationEvents.js
@@ -1,6 +1,8 @@
 // navigationEvents.js
+import { getOrders } from '../api/orders';
+import { showOrders } from '../pages/ordersPage';
 
-const navigationEvents = () => {
+const navigationEvents = (user) => {
   // HOME
   document.querySelector('#home').addEventListener('click', (e) => {
     e.preventDefault();
@@ -10,7 +12,9 @@ const navigationEvents = () => {
   // VIEW ORDERS
   document.querySelector('#view-orders').addEventListener('click', (e) => {
     e.preventDefault();
-    // TODO: Add orders view rendering
+    console.warn('#view-orders clicked');
+
+    getOrders(user.uid).then(showOrders);
   });
 
   // CREATE ORDER

--- a/pages/homePage.js
+++ b/pages/homePage.js
@@ -1,0 +1,5 @@
+const homePage = (uid) => {
+  console.warn(uid);
+};
+
+export default homePage;

--- a/pages/ordersPage.js
+++ b/pages/ordersPage.js
@@ -23,6 +23,10 @@ const showOrders = (array) => {
             <li class="order-details-item">${item.customer_email}</li>
             <li class="order-details-item">${item.order_type}</li>
           </ul>
+          <div class="order-card-btns-container">
+            <a href="#" class="order-card-details--${item.firebaseKey}">View Details</a>
+            <a href="#" class="order-card-delete--${item.firebaseKey}">Delete</a>
+          </div>
         </div>
       </div>`;
   });

--- a/utils/clearDom.js
+++ b/utils/clearDom.js
@@ -1,8 +1,6 @@
 const clearDOM = () => {
-  document.querySelector('#main-container').innerHTML = '';
-  document.querySelector('#navigation').innerHTML = '';
+  document.querySelector('#orders-container').innerHTML = '';
   document.querySelector('#login-form-container').innerHTML = '';
-  document.querySelector('#app').innerHTML = '';
   document.querySelector('#view').innerHTML = '';
   document.querySelector('#add-button').innerHTML = '';
 };

--- a/utils/startApp.js
+++ b/utils/startApp.js
@@ -1,10 +1,14 @@
 import logoutButton from '../components/buttons/logoutButton';
 import navBar from '../components/navbar';
+import navigationEvents from '../events/navigationEvents';
 import homePage from '../pages/homePage';
+import domBuilder from '../shared/domBuilder';
 
 const startApp = (user) => {
   document.querySelector('#login-form-container').innerHTML = ''; // Clear login button
+  domBuilder();
   navBar(user); // Pass user data to navbar
+  navigationEvents(user);
   logoutButton(); // Add logout button to navbar
   homePage(user); // Show homepage with user-specific content
 };


### PR DESCRIPTION
…in navbar

## Description

- Added 'details' and 'delete' links to orders cards generated by `showOrders`; currently they do nothing but they have classes of `.order-card-details` and `order-card-delete`. These will need to be changed to `order-card-details--${firebaseKey}` and `order-card-delete--${firebaseKey}.
- Removed lines from `clearDOM` that were deleting all content from the navbar, main container, and app divs.

## Related Issue
#54 

## Motivation and Context
- Orders can now be viewed on the DOM when clicking View Orders in the navbar.

## How Can This Be Tested?
- You will need your user uid. Use Postman to POST cards to firebase with your uid attached or else you will not be able to see the cards.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
