### PR TITLE
added functionality for deleting orders

### DIFF
--- a/events/domEvents.js
+++ b/events/domEvents.js
@@ -1,10 +1,12 @@
 import { getOrderItems } from '../api/orderItems';
+import { getOrders, deleteSingleOrder } from '../api/orders';
 // eslint-disable-next-line import/extensions
 import { emptyOrderItems, showOrderItems } from '../pages/orderItemsPage';
+import { showOrders } from '../pages/ordersPage';
 import clearDOM from '../utils/clearDom';
 import addOrderItemForm from '../pages/createOrderItemPage';
 
-const domEvents = () => {
+const domEvents = (user) => {
   document.querySelector('#main-container').addEventListener('click', (e) => {
     // CLICK EVENT ON DETAILS BUTTON OF AN ORDER
     if (e.target.id.includes('order-card-details')) {
@@ -24,6 +26,14 @@ const domEvents = () => {
       addOrderItemForm(firebaseKey);
     }
 
+    // CLICK EVENT ON DELETE BUTTON OF AN ORDER
+    if (e.target.id.includes('order-card-delete')) {
+      const [, firebaseKey] = e.target.id.split('--');
+
+      deleteSingleOrder(firebaseKey).then(() => {
+        getOrders(user.uid).then(showOrders);
+      });
+    }
     // Below closes out the higher-order addEventListener and domEvents
   });
 };

--- a/pages/createOrderPage.js
+++ b/pages/createOrderPage.js
@@ -15,7 +15,7 @@ const createOrderPage = (obj = {}) => {
         <input type="tel" class="form-control" id="customer-phone" aria-describedby="customer-phone" placeholder="555-555-5555" pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}" value="${obj.customer_phone || ''}" required>
       </div>
       <div class="form-group">
-        <label for="customer-email"></label>
+        <label for="customer-email">Email address:</label>
         <input type="email" class="form-control" id="customer-email" placeholder="example@email.com" value="${obj.customer_email || ''}" required>
       </div>
       <div class="form-group" id="order-type-select">

--- a/startApp.js
+++ b/startApp.js
@@ -9,7 +9,7 @@ import domBuilder from './shared/domBuilder';
 const startApp = (user) => {
   domBuilder(); // Set up the main container structure
   navBar(user); // Set up navigation
-  domEvents();
+  domEvents(user);
   logoutButton(); // Add logout button to navbar
   navigationEvents(user); // Set up navigation events
   formEvents(user); // Set up form events


### PR DESCRIPTION
## Description
Added an event listener in `domEvents` to check when the delete button on an order card is clicked. It then calls the `deleteSingleOrder` promise and then renders the remaining orders to the DOM.

## Related Issue
#46 

## Motivation and Context
Order cards can now be removed when no longer needed

## How Can This Be Tested?
Click 'View Orders' and then find the word 'Delete' on an order card and click that.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
