### PR TITLE
added functionality to update an order item

### DIFF
--- a/api/orderItems.js
+++ b/api/orderItems.js
@@ -20,7 +20,6 @@ const getOrderItems = (firebaseKey) => new Promise((resolve, reject) => {
 });
 
 // GET SINGLE ORDER_ITEM
-// We likely won't need to use this, but leaving it just in case
 const getSingleOrderItem = (firebaseKey) => new Promise((resolve, reject) => {
   fetch(`${endpoint}/order_items/${firebaseKey}.json`, {
     method: 'GET',

--- a/events/domEvents.js
+++ b/events/domEvents.js
@@ -1,4 +1,4 @@
-import { getOrderItems } from '../api/orderItems';
+import { getOrderItems, getSingleOrderItem } from '../api/orderItems';
 import { getOrders, deleteSingleOrder, getSingleOrder } from '../api/orders';
 import { emptyOrderItems, showOrderItems } from '../pages/orderItemsPage';
 import { showOrders } from '../pages/ordersPage';
@@ -26,6 +26,15 @@ const domEvents = (user) => {
       clearDOM();
       const [, firebaseKey] = e.target.id.split('--'); // destructuring to assign firebasekey of the order, which was passed into showOrderItems to store in the add item button
       addOrderItemForm(firebaseKey);
+    }
+
+    // CLICK EVENT ON "EDIT" BUTTON ON AN ORDER ITEM
+    // get the firebase key of the order item
+    if (e.target.id.includes('edit-orderItem-btn')) {
+      const [, orderItemFirebaseKey, orderFirebaseKey] = e.target.id.split('--');
+      getSingleOrderItem(orderItemFirebaseKey).then((orderItemObj) => {
+        addOrderItemForm(orderFirebaseKey, orderItemObj);
+      });
     }
 
     // CLICK EVENT ON DELETE BUTTON OF AN ORDER

--- a/pages/createOrderItemPage.js
+++ b/pages/createOrderItemPage.js
@@ -3,12 +3,14 @@ import renderToDOM from '../utils/renderToDom';
 
 // USING THIS FORM FOR BOTH CREATE AND UPDATE ORDER ITEMS
 const addOrderItemForm = (firebaseKey, obj = {}) => {
+  console.warn('Firebase Key:', firebaseKey);
+  console.warn('Order Item Object:', obj);
   clearDOM();
   // id of the form ternary: The first condition, if the order item already has a firebase key (if it already exists), is for updating. The second condition, if not obj does not yet have a firebase key, is for creating, and it inserts the associated order's firebasekey in the id for use in addOrderItemForm
   // "submit-the-orderItem" may seem like a weird name. but having it as "submit-orderItem" conflicted with other functions in formEvents that targeted id's also containing "submit-order," so please leave as is!
   // type="number" step="0.01" of the price input: type restricts the input to numerical values, and step allows decimal values with up to two decimal places
   const domString = `
-    <form id="${obj.firebaseKey ? `update-orderItem--${obj.firebaseKey}` : `submit-the-orderItem--${firebaseKey}`}" class="mb-4">
+    <form id="${obj.firebaseKey ? `update-the-orderItem--${obj.firebaseKey}` : `submit-the-orderItem--${firebaseKey}`}" class="mb-4">
       <div class="form-group">
         <label for="image"Item Name</label>
         <input type="text" class="form-control" id="item_name" placeholder="Item Name" value="${obj.item_name || ''}" required>

--- a/pages/orderItemsPage.js
+++ b/pages/orderItemsPage.js
@@ -25,7 +25,7 @@ const showOrderItems = (array, firebaseKey) => {
       <div class="card-body">
         <h5 class="card-title">${item.item_name}</h5>
         <h6 class="card-subtitle mb-2 text-muted">PRICE: ${item.item_price}</h6>
-        <i class="fas fa-edit btn btn-info" id="update-orderItem-btn--${item.firebaseKey}"></i>
+        <i class="fas fa-edit btn btn-info" id="edit-orderItem-btn--${item.firebaseKey}"></i>
         <i class="btn btn-danger fas fa-trash-alt" id="delete-orderItem-btn--${item.firebaseKey}"></i>
       </div>
     </div>


### PR DESCRIPTION
## Description
- added functionality to update an order item. added event listener to the edit button in dom events and added event listener to the submit button on the form in form events. had to make some changes to id's in my other pages to be compatible with destructuring 
- Updated the event listener for the "Edit" button on order items to handle both the order item Firebase key and the order Firebase key.
- Changed the ID of the edit button from `update-orderItem-btn` to `edit-orderItem-btn` to avoid conflicts with the form's ID `update-orderItem`.
- Modified the button's `id` in `showOrderItems` to include both the `orderItemFirebaseKey` and the `orderFirebaseKey`, allowing both keys to be passed when editing an order item.
- Changed the `update-orderItem` form's ID to `update-the-orderItem` to resolve conflicts with the `update-order` button.

## Related Issue
#59

## How Can This Be Tested?
NOTE: this won't work on some older created order items because some older items. Please create a new order item to test on.
- Go to the orders page and click the "Edit" button on the order item.
- Ensure the correct form is pre-filled with the order item data.
- update something on the form
- submit form and ensure the order item's info is updated on the card

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)